### PR TITLE
Fix auto discovery for new tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,6 @@
-file(GLOB TEST_SOURCES "test_*.cpp")
+# Automatic reconfigure for new tests (CMake 3.12+)
+file(GLOB TEST_SOURCES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/test_*.cpp")
+message(STATUS "Found tests: ${TEST_SOURCES}")
 
 foreach(test_file ${TEST_SOURCES})
     get_filename_component(test_name ${test_file} NAME_WE)


### PR DESCRIPTION
## Description

Fixes the auto discovery for new tests by using the CONFIGURE_DEPENDS option introduced in CMake 3.12+

## Issues

<!-- use if this PR fully resolves the issue -->

Closes #8 

<!-- use if this PR is linked but should not close the issue -->

Related: #<issue-number>

## Testing

- Create a new .cpp testcase
- Run the build & run tests command
