### PR TITLE
Add timeouts to tests and introduce helper test functions

### DIFF
--- a/include/malloc_from_scratch/memory_internal.h
+++ b/include/malloc_from_scratch/memory_internal.h
@@ -44,6 +44,31 @@ MemoryBlock* getMemoryBlockFromAddress(void* address);
 size_t getSizeOfAllocatedMemoryBlock(MemoryBlock* block);
 void* getErrorCodeInVoidPtr(size_t error_code);
 
+// Test helper functions to inspect allocator state
+inline size_t getTotalUsedMemory() { return total_memory_allocated; }
+inline size_t getFreeBlockInfo(int type)
+{
+    // type 0 = address of first free block
+    // type 1 = size of first free block
+    MemoryBlock* current = block_list_head;
+    while (current != nullptr)
+    {
+        if (!current->allocated_)
+        {
+            if (type == 0)
+            {
+                return reinterpret_cast<size_t>(getPayloadAddress(current));
+            }
+            else if (type == 1)
+            {
+                return current->size_;
+            }
+        }
+        current = current->next_;
+    }
+    return 0;
+}
+
 } // namespace internal
 } // namespace mem
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,22 @@ foreach(test_file ${TEST_SOURCES})
             LABELS "${test_category}"
         )
     endif()
+
+    # Set default timeout for all tests (10 seconds)
+    set_tests_properties(${test_name} PROPERTIES
+        TIMEOUT 10
+    )
+
+    # Longer timeouts for specific categories that need more time
+    if(test_category MATCHES "stress")
+        set_tests_properties(${test_name} PROPERTIES
+            TIMEOUT 30
+        )
+    elseif(test_category MATCHES "concurrency")
+        set_tests_properties(${test_name} PROPERTIES
+            TIMEOUT 20
+        )
+    endif()
 endforeach()
 
 # Add strace tests for all categories except those that would produce false positives

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -1,6 +1,7 @@
 #ifndef TEST_UTILS_H
 #define TEST_UTILS_H
 
+#include "malloc_from_scratch/memory_internal.h"
 #include <cstring>
 #include <iostream>
 
@@ -55,5 +56,9 @@ inline void test_pass()
 #define ASSERT_NULL(ptr) assert_null((ptr), __FILE__, __LINE__)
 #define ASSERT_NOT_NULL(ptr) assert_not_null((ptr), __FILE__, __LINE__)
 #define TEST_PASS() test_pass()
+
+// Internal test helpers for convenience
+using mem::internal::getFreeBlockInfo;
+using mem::internal::getTotalUsedMemory;
 
 #endif // TEST_UTILS_H


### PR DESCRIPTION
## Description

Add timeouts to tests and introduce helper test functions. Timeouts are added via the cmake tests config and helper functions are added in the header files.

## Issues

<!-- use if this PR fully resolves the issue -->

Closes #28 

<!-- use if this PR is linked but should not close the issue -->

Related: #<issue-number>

## Testing

<!-- Steps or notes on how reviewers can verify. -->
