### PR TITLE
Fix malloc and free performance by updating block list management

### DIFF
--- a/include/malloc_from_scratch/memory_internal.h
+++ b/include/malloc_from_scratch/memory_internal.h
@@ -18,6 +18,7 @@ struct MemoryBlock
 };
 
 inline MemoryBlock* block_list_head = nullptr;
+inline MemoryBlock* block_list_tail = nullptr;
 inline void* heap_start = nullptr;
 inline size_t total_memory_allocated = 0;
 inline pthread_mutex_t allocator_mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/src/free.cpp
+++ b/src/free.cpp
@@ -48,10 +48,12 @@ void free(void* ptr)
         if (block_previous_from_last != nullptr)
         {
             block_previous_from_last->next_ = nullptr;
+            internal::block_list_tail = block_previous_from_last;
         }
         else
         {
             internal::block_list_head = nullptr;
+            internal::block_list_tail = nullptr;
         }
         internal::decreaseHeap(block_list_tail);
     }

--- a/src/malloc.cpp
+++ b/src/malloc.cpp
@@ -144,18 +144,17 @@ void* getMemoryBlockSplitAddress(MemoryBlock* new_block, size_t size)
 
 void insertMemoryBlockAtEnd(MemoryBlock** block_list_head, MemoryBlock* new_block)
 {
+    new_block->next_ = nullptr;
+
     if (*block_list_head == nullptr)
     {
         *block_list_head = new_block;
+        block_list_tail = new_block;
     }
     else
     {
-        MemoryBlock* current = *block_list_head;
-        while (current->next_ != nullptr)
-        {
-            current = current->next_;
-        }
-        current->next_ = new_block;
+        block_list_tail->next_ = new_block;
+        block_list_tail = new_block;
     }
 }
 


### PR DESCRIPTION
## Description

Fix malloc and free performance by updating block list management. A tail pointer is used for O(1) inserts instead of O(n) - scanning the whole linked list every time. This gives a huge speed boost and was confirmed with stress tests.

## Issues

<!-- use if this PR fully resolves the issue -->

Closes #38 

<!-- use if this PR is linked but should not close the issue -->

Related: #<issue-number>

## Testing

Stress tests
