### PR TITLE
Refactor encapsulation of allocator internals

### DIFF
--- a/include/malloc_from_scratch/memory_internal.h
+++ b/include/malloc_from_scratch/memory_internal.h
@@ -17,11 +17,11 @@ struct MemoryBlock
     MemoryBlock* next_;
 };
 
-inline MemoryBlock* block_list_head = nullptr;
-inline MemoryBlock* block_list_tail = nullptr;
-inline void* heap_start = nullptr;
-inline size_t total_memory_allocated = 0;
-inline pthread_mutex_t allocator_mutex = PTHREAD_MUTEX_INITIALIZER;
+extern MemoryBlock* block_list_head;
+extern MemoryBlock* block_list_tail;
+extern void* heap_start;
+extern size_t total_memory_allocated;
+extern pthread_mutex_t allocator_mutex;
 
 constexpr size_t BLOCK_METADATA_SIZE = sizeof(MemoryBlock);
 constexpr size_t CHUNK_SIZE = 65536;
@@ -47,36 +47,14 @@ bool isBlockCorrupted(MemoryBlock* block);
 void* getPayloadAddress(MemoryBlock* block);
 MemoryBlock* getMetadata(void* payload_address);
 MemoryBlock* getMemoryBlockFromAddress(void* address);
-size_t getSizeOfAllocatedMemoryBlock(MemoryBlock* block);
 bool isPointerInHeap(void* ptr);
 void* getErrorCodeInVoidPtr(size_t error_code);
 bool isValidBlock(MemoryBlock* block);
 bool checkCanary(MemoryBlock* block);
 
 // Test helper functions to inspect allocator state
-inline size_t getTotalUsedMemory() { return total_memory_allocated; }
-inline size_t getFreeBlockInfo(int type)
-{
-    // type 0 = address of first free block
-    // type 1 = size of first free block
-    MemoryBlock* current = block_list_head;
-    while (current != nullptr)
-    {
-        if (!current->allocated_)
-        {
-            if (type == 0)
-            {
-                return reinterpret_cast<size_t>(getPayloadAddress(current));
-            }
-            else if (type == 1)
-            {
-                return current->size_;
-            }
-        }
-        current = current->next_;
-    }
-    return 0;
-}
+size_t getTotalUsedMemory();
+size_t getFreeBlockInfo(int type);
 
 } // namespace internal
 } // namespace mem

--- a/src/malloc.cpp
+++ b/src/malloc.cpp
@@ -192,11 +192,6 @@ MemoryBlock* getMemoryBlockFromAddress(void* address)
     return reinterpret_cast<MemoryBlock*>(address);
 }
 
-size_t getSizeOfAllocatedMemoryBlock(MemoryBlock* block)
-{
-    return reinterpret_cast<size_t>(getPayloadAddress(block));
-}
-
 bool isPointerInHeap(void* ptr)
 {
     void* current_program_break = sbrk(0);

--- a/src/memory_internal.cpp
+++ b/src/memory_internal.cpp
@@ -1,0 +1,39 @@
+#include "malloc_from_scratch/memory_internal.h"
+
+namespace mem
+{
+namespace internal
+{
+
+MemoryBlock* block_list_head = nullptr;
+MemoryBlock* block_list_tail = nullptr;
+void* heap_start = nullptr;
+size_t total_memory_allocated = 0;
+pthread_mutex_t allocator_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+size_t getTotalUsedMemory() { return total_memory_allocated; }
+size_t getFreeBlockInfo(int type)
+{
+    // type 0 = address of first free block
+    // type 1 = size of first free block
+    MemoryBlock* current = block_list_head;
+    while (current != nullptr)
+    {
+        if (!current->allocated_)
+        {
+            if (type == 0)
+            {
+                return reinterpret_cast<size_t>(getPayloadAddress(current));
+            }
+            else if (type == 1)
+            {
+                return current->size_;
+            }
+        }
+        current = current->next_;
+    }
+    return 0;
+}
+
+} // namespace internal
+} // namespace mem


### PR DESCRIPTION
## Description

Refactor `memory_internal` by moving allocator globals from .h into a single .cpp. This fixes duplication and improves encapsulation. Also removed unused function: `size_t getSizeOfAllocatedMemoryBlock(MemoryBlock* block);`.

## Issues

<!-- use if this PR fully resolves the issue -->

Closes #56 

<!-- use if this PR is linked but should not close the issue -->

Related: #<issue-number>

## Testing

Run tests / CI
